### PR TITLE
removed closing round bracket from Arduino example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ void setup() {
 void eventCallback(JSONVar data) {
     // Do something, even sending events right back!
     WebSerial.send("event-from-arduino", data);
-});
+};
 
 void loop() {
   // Check for new serial data every loop


### PR DESCRIPTION
The Arduino example has an extra closing round bracket so the given example doesn't compile. 
This is also present in the DOCS at https://github.com/fmgrafikdesign/SimpleWebSerialJS/tree/main/docs